### PR TITLE
Update link to the OpenStack charm guide

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -1,1 +1,1 @@
-For details on development of OpenStack Charms please refer to the [OpenStack Charm Guide][https://github.com/openstack-charmers/openstack-charm-guide].
+For details on development of OpenStack Charms please refer to the [OpenStack Charm Guide](http://docs.openstack.org/developer/charm-guide/).


### PR DESCRIPTION
The OpenStack charm guide now is published in docs.openstack.org
